### PR TITLE
Remove duplicate wp_head call in header

### DIFF
--- a/header.php
+++ b/header.php
@@ -14,7 +14,6 @@
 <html <?php language_attributes(); ?>>
 <head>
   <?php wp_head(); ?>
-  <?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>


### PR DESCRIPTION
## Summary
- remove the duplicate wp_head() invocation in header.php to avoid duplicate asset output

## Testing
- php -l header.php

------
https://chatgpt.com/codex/tasks/task_e_68d584d208808333a9c986dfdc00b909