### PR TITLE
Add missing CSS and JavaScript assets

### DIFF
--- a/css/about-page.css
+++ b/css/about-page.css
@@ -1,0 +1,304 @@
+/*
+ * Styles for the About page template.
+ */
+
+.page-header {
+  background: linear-gradient(135deg, rgba(69, 123, 157, 0.88), rgba(230, 57, 70, 0.75)), url('../assets/images/bg-dark.jpg') center/cover no-repeat;
+  padding: 120px 0 80px;
+  text-align: center;
+}
+
+.page-title {
+  font-size: clamp(2.4rem, 4vw, 3.6rem);
+  margin-bottom: 18px;
+}
+
+.page-subtitle {
+  color: rgba(241, 250, 238, 0.85);
+  line-height: 1.7;
+}
+
+.main-content {
+  background: #05070d;
+  padding: 90px 0 120px;
+}
+
+.content-container {
+  max-width: 1180px;
+}
+
+.about-intro {
+  margin-bottom: 48px;
+  color: rgba(241, 250, 238, 0.8);
+  line-height: 1.9;
+  font-size: 1.05rem;
+}
+
+.concept-section {
+  margin-bottom: 90px;
+}
+
+.concept-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 32px;
+  align-items: center;
+  background: rgba(12, 16, 24, 0.9);
+  border-radius: 26px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.concept-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  min-height: 320px;
+}
+
+.concept-content {
+  padding: 48px;
+  display: grid;
+  gap: 16px;
+}
+
+.concept-subtitle {
+  letter-spacing: 0.4em;
+  color: rgba(241, 250, 238, 0.6);
+  font-weight: 600;
+}
+
+.concept-title {
+  font-size: clamp(2rem, 3vw, 2.6rem);
+}
+
+.concept-text {
+  color: rgba(241, 250, 238, 0.75);
+  line-height: 1.8;
+}
+
+.features-section {
+  margin-bottom: 90px;
+}
+
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 28px;
+}
+
+.feature-card {
+  background: rgba(12, 16, 24, 0.9);
+  border-radius: 22px;
+  padding: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: grid;
+  gap: 18px;
+  position: relative;
+  overflow: hidden;
+}
+
+.feature-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(145deg, rgba(230, 57, 70, 0), rgba(230, 57, 70, 0.25));
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.feature-card:hover::after,
+.feature-card.is-visible::after {
+  opacity: 1;
+}
+
+.feature-icon {
+  width: 58px;
+  height: 58px;
+  border-radius: 16px;
+  background: rgba(230, 57, 70, 0.18);
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+  font-size: 1.4rem;
+}
+
+.feature-title {
+  font-size: 1.3rem;
+  letter-spacing: 0.08em;
+}
+
+.feature-text {
+  color: rgba(241, 250, 238, 0.75);
+  line-height: 1.8;
+}
+
+.history-section {
+  margin-bottom: 90px;
+}
+
+.timeline {
+  position: relative;
+  padding-left: 34px;
+  display: grid;
+  gap: 32px;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 16px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(to bottom, rgba(230, 57, 70, 0.9), rgba(69, 123, 157, 0.3));
+}
+
+.timeline-item {
+  position: relative;
+  background: rgba(12, 16, 24, 0.9);
+  border-radius: 20px;
+  padding: 24px 28px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  transform: translateX(0);
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.timeline-item::before {
+  content: '';
+  position: absolute;
+  left: -18px;
+  top: 26px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--primary);
+  box-shadow: 0 0 0 6px rgba(230, 57, 70, 0.18);
+}
+
+.timeline-item.is-visible {
+  transform: translateX(8px);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+}
+
+.timeline-item.is-expanded {
+  box-shadow: 0 24px 55px rgba(0, 0, 0, 0.55);
+  border-color: rgba(230, 57, 70, 0.35);
+}
+
+.timeline-date {
+  font-size: 0.95rem;
+  letter-spacing: 0.1em;
+  color: rgba(241, 250, 238, 0.55);
+  margin-bottom: 10px;
+}
+
+.timeline-title {
+  font-size: 1.3rem;
+  margin-bottom: 12px;
+}
+
+.timeline-text {
+  color: rgba(241, 250, 238, 0.75);
+  line-height: 1.8;
+}
+
+.team-section {
+  margin-bottom: 90px;
+}
+
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 28px;
+}
+
+.team-card {
+  background: rgba(12, 16, 24, 0.9);
+  border-radius: 22px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+}
+
+.team-card img {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+}
+
+.team-content {
+  padding: 24px;
+  display: grid;
+  gap: 10px;
+}
+
+.team-name {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.team-role {
+  color: rgba(241, 250, 238, 0.6);
+  letter-spacing: 0.1em;
+}
+
+.team-bio {
+  color: rgba(241, 250, 238, 0.7);
+  line-height: 1.7;
+}
+
+.about-cta {
+  background: linear-gradient(130deg, rgba(29, 53, 87, 0.95), rgba(230, 57, 70, 0.75));
+  border-radius: 26px;
+  padding: 48px;
+  text-align: center;
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.5);
+}
+
+.about-cta h3 {
+  font-size: clamp(2rem, 3vw, 2.8rem);
+  margin-bottom: 16px;
+}
+
+.about-cta p {
+  color: rgba(241, 250, 238, 0.75);
+  line-height: 1.8;
+  margin-bottom: 24px;
+}
+
+.about-cta .btn {
+  min-width: 180px;
+}
+
+@media (max-width: 992px) {
+  .concept-content {
+    padding: 32px;
+  }
+}
+
+@media (max-width: 768px) {
+  .timeline {
+    padding-left: 18px;
+  }
+
+  .timeline::before {
+    left: 8px;
+  }
+
+  .timeline-item::before {
+    left: -12px;
+  }
+}
+
+@media (max-width: 640px) {
+  .concept-content {
+    padding: 26px;
+  }
+
+  .features-grid,
+  .team-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/css/equipment-page.css
+++ b/css/equipment-page.css
@@ -1,0 +1,245 @@
+/*
+ * Styles for the Equipment list page template.
+ */
+
+.page-header {
+  background: linear-gradient(140deg, rgba(230, 57, 70, 0.8), rgba(4, 8, 16, 0.95)), url('../assets/images/bg-dark.jpg') center/cover no-repeat;
+  padding: 120px 0 80px;
+  text-align: center;
+}
+
+.page-title {
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+  margin-bottom: 18px;
+}
+
+.page-subtitle {
+  color: rgba(241, 250, 238, 0.85);
+}
+
+.main-content {
+  background: #05070d;
+  padding: 90px 0 120px;
+}
+
+.content-container {
+  max-width: 1180px;
+}
+
+.equipment-intro {
+  margin-bottom: 48px;
+  color: rgba(241, 250, 238, 0.75);
+  line-height: 1.8;
+}
+
+.equipment-tabs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 14px;
+  margin-bottom: 32px;
+}
+
+.equipment-tab {
+  padding: 16px;
+  border-radius: 14px;
+  text-align: center;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  background: rgba(255, 255, 255, 0.05);
+  cursor: pointer;
+  transition: var(--transition);
+  border: 1px solid transparent;
+}
+
+.equipment-tab:hover,
+.equipment-tab:focus {
+  border-color: rgba(230, 57, 70, 0.6);
+  box-shadow: 0 0 0 3px rgba(230, 57, 70, 0.12);
+}
+
+.equipment-tab.active {
+  background: var(--primary);
+  color: var(--light);
+}
+
+.equipment-content {
+  display: none;
+  animation: fadeIn 0.35s ease;
+}
+
+.equipment-content.active {
+  display: block;
+}
+
+.equipment-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 26px;
+}
+
+.equipment-card {
+  background: rgba(10, 13, 20, 0.92);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.equipment-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+}
+
+.equipment-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.equipment-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: rgba(230, 57, 70, 0.15);
+  display: grid;
+  place-items: center;
+  font-size: 1.2rem;
+  color: var(--accent);
+}
+
+.equipment-title {
+  font-size: 1.2rem;
+  letter-spacing: 0.06em;
+}
+
+.equipment-list {
+  list-style: none;
+  display: grid;
+  gap: 10px;
+  color: rgba(241, 250, 238, 0.8);
+}
+
+.equipment-item {
+  position: relative;
+  padding-left: 18px;
+  line-height: 1.7;
+}
+
+.equipment-item::before {
+  content: '\2022';
+  position: absolute;
+  left: 0;
+  color: var(--primary);
+}
+
+.equipment-note {
+  font-size: 0.92rem;
+  color: rgba(241, 250, 238, 0.6);
+}
+
+.equipment-tools {
+  margin: 32px 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.equipment-search {
+  flex: 1;
+  min-width: 220px;
+  position: relative;
+}
+
+.equipment-search input {
+  width: 100%;
+  padding: 12px 16px 12px 42px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--accent);
+}
+
+.equipment-search-icon {
+  position: absolute;
+  left: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: rgba(241, 250, 238, 0.6);
+}
+
+.equipment-export {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 18px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--accent);
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.equipment-export:hover {
+  background: var(--primary);
+  color: var(--light);
+}
+
+.equipment-export-status {
+  font-size: 0.9rem;
+  color: rgba(241, 250, 238, 0.65);
+  display: none;
+}
+
+.equipment-export-status.is-visible {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.equipment-highlight {
+  background: rgba(230, 57, 70, 0.12) !important;
+  border-color: rgba(230, 57, 70, 0.35) !important;
+}
+
+.no-results-message {
+  margin-top: 24px;
+  padding: 24px;
+  border-radius: 18px;
+  text-align: center;
+  background: rgba(12, 16, 24, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  color: rgba(241, 250, 238, 0.7);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  .equipment-card {
+    padding: 22px;
+  }
+
+  .equipment-tools {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .equipment-export {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/css/events-page.css
+++ b/css/events-page.css
@@ -1,0 +1,529 @@
+/*
+ * Styles for the Events page template.
+ * Includes navigation tabs, filters, event cards, calendar layout and modal.
+ */
+
+.page-header {
+  background: linear-gradient(135deg, rgba(69, 123, 157, 0.85), rgba(10, 10, 10, 0.85)), url('../assets/images/bg-dark.jpg') center/cover no-repeat;
+  padding: 120px 0 80px;
+  text-align: center;
+}
+
+.page-title {
+  font-size: clamp(2.2rem, 4vw, 3.4rem);
+  margin-bottom: 16px;
+}
+
+.page-subtitle {
+  color: rgba(241, 250, 238, 0.85);
+  line-height: 1.7;
+}
+
+.main-content {
+  padding: 90px 0 120px;
+  background-color: #080a0f;
+}
+
+.content-container {
+  max-width: 1200px;
+}
+
+.intro-text {
+  margin-bottom: 40px;
+  color: rgba(241, 250, 238, 0.75);
+}
+
+.events-nav {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 14px;
+  margin-bottom: 32px;
+}
+
+.events-nav-item {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 14px;
+  padding: 16px;
+  text-align: center;
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  transition: var(--transition);
+  border: 1px solid transparent;
+}
+
+.events-nav-item:hover,
+.events-nav-item:focus {
+  border-color: rgba(69, 123, 157, 0.6);
+  box-shadow: 0 0 0 3px rgba(69, 123, 157, 0.1);
+}
+
+.events-nav-item.active {
+  background: var(--secondary);
+  color: var(--light);
+}
+
+.events-filter {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 24px;
+  background: rgba(12, 16, 24, 0.85);
+  border-radius: 18px;
+  margin-bottom: 36px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.filter-label {
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.filter-dropdown {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--accent);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 10px 14px;
+  min-width: 180px;
+}
+
+.search-form {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+}
+
+.search-input {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 10px 14px;
+  color: var(--accent);
+  min-width: 220px;
+}
+
+.search-button {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--primary);
+  color: var(--light);
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--transition);
+}
+
+.search-button:hover {
+  opacity: 0.85;
+}
+
+.events-list {
+  display: none;
+}
+
+.events-list.active {
+  display: block;
+}
+
+.event-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 28px;
+}
+
+.event-card {
+  background: rgba(14, 18, 26, 0.9);
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  position: relative;
+}
+
+.event-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(230, 57, 70, 0) 20%, rgba(230, 57, 70, 0.25));
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.event-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+}
+
+.event-card:hover::after {
+  opacity: 1;
+}
+
+.event-image img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  display: block;
+}
+
+.event-content {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.event-date-badge {
+  align-self: flex-start;
+  padding: 6px 14px;
+  background: rgba(230, 57, 70, 0.85);
+  border-radius: 999px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.event-title {
+  font-size: 1.3rem;
+  line-height: 1.4;
+}
+
+.event-details {
+  display: grid;
+  gap: 10px;
+  color: rgba(241, 250, 238, 0.75);
+}
+
+.event-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.event-description {
+  font-size: 0.95rem;
+  color: rgba(241, 250, 238, 0.7);
+  line-height: 1.7;
+}
+
+.event-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px 24px;
+  margin-top: auto;
+}
+
+.event-category {
+  font-size: 0.9rem;
+  color: rgba(241, 250, 238, 0.6);
+  letter-spacing: 0.08em;
+}
+
+.event-card.is-hidden {
+  display: none !important;
+}
+
+.calendar-view {
+  display: none;
+  background: rgba(14, 18, 26, 0.9);
+  border-radius: 22px;
+  padding: 32px;
+  margin-bottom: 40px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.calendar-view.active {
+  display: block;
+}
+
+.calendar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.calendar-nav {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.calendar-nav-button {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.calendar-nav-button:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.calendar-title {
+  font-size: 1.4rem;
+  letter-spacing: 0.08em;
+}
+
+.calendar-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.calendar-table th,
+.calendar-table td {
+  padding: 14px 10px;
+  text-align: center;
+  border-radius: 12px;
+  position: relative;
+}
+
+.calendar-table tbody tr + tr td {
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.calendar-day {
+  height: 100px;
+  position: relative;
+}
+
+.calendar-day.has-event {
+  background: rgba(230, 57, 70, 0.1);
+  border: 1px solid rgba(230, 57, 70, 0.25);
+}
+
+.calendar-event {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: 8px;
+  background: rgba(230, 57, 70, 0.85);
+  border-radius: 12px;
+  padding: 6px 8px;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 40px;
+}
+
+.pagination .pagination-item,
+.pagination li {
+  list-style: none;
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.pagination .pagination-item.active,
+.pagination .current {
+  background: var(--primary);
+  color: var(--light);
+}
+
+.no-events-message {
+  text-align: center;
+  padding: 40px;
+  border-radius: 18px;
+  background: rgba(12, 16, 24, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  color: rgba(241, 250, 238, 0.7);
+}
+
+.event-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 7, 12, 0.92);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  z-index: 9999;
+}
+
+.event-modal.active {
+  display: flex;
+}
+
+.modal-content {
+  background: rgba(10, 12, 18, 0.96);
+  border-radius: 22px;
+  max-width: 960px;
+  width: 100%;
+  overflow: hidden;
+  position: relative;
+  box-shadow: 0 40px 90px rgba(0, 0, 0, 0.55);
+}
+
+.modal-close {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  width: 46px;
+  height: 46px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--accent);
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.modal-close:hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.modal-image img {
+  width: 100%;
+  max-height: 360px;
+  object-fit: cover;
+  display: block;
+}
+
+.modal-body {
+  padding: 32px;
+}
+
+.event-modal-title {
+  font-size: 2rem;
+  margin-bottom: 16px;
+}
+
+.event-modal-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+  margin-bottom: 28px;
+}
+
+.event-meta-item {
+  display: flex;
+  gap: 14px;
+}
+
+.event-meta-icon {
+  width: 46px;
+  height: 46px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.05);
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.event-details-section + .event-details-section {
+  margin-top: 28px;
+}
+
+.event-details-title {
+  font-size: 1.3rem;
+  margin-bottom: 12px;
+}
+
+.event-details-content,
+.ticket-options {
+  color: rgba(241, 250, 238, 0.75);
+  line-height: 1.7;
+}
+
+.ticket-option {
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.modal-footer {
+  margin-top: 30px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: center;
+}
+
+.share-links {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.share-link {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--accent);
+  transition: var(--transition);
+}
+
+.share-link:hover {
+  background: var(--primary);
+  color: var(--light);
+}
+
+@media (max-width: 992px) {
+  .search-form {
+    margin-left: 0;
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .search-input {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .modal-body {
+    padding: 26px 22px;
+  }
+}
+
+@media (max-width: 640px) {
+  .calendar-view {
+    padding: 22px;
+  }
+
+  .event-modal-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .modal-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .share-links {
+    justify-content: center;
+  }
+}

--- a/css/floor-map-page.css
+++ b/css/floor-map-page.css
@@ -1,0 +1,245 @@
+/*
+ * Styles for the floor map & access page template.
+ */
+
+.page-header {
+  background: linear-gradient(135deg, rgba(29, 53, 87, 0.9), rgba(69, 123, 157, 0.75)), url('../assets/images/bg-dark.jpg') center/cover no-repeat;
+  padding: 120px 0 80px;
+  text-align: center;
+}
+
+.page-title {
+  font-size: clamp(2.3rem, 4vw, 3.4rem);
+  margin-bottom: 18px;
+}
+
+.page-subtitle {
+  color: rgba(241, 250, 238, 0.85);
+  line-height: 1.7;
+}
+
+.main-content {
+  background: #04070d;
+  padding: 90px 0 120px;
+}
+
+.content-container {
+  max-width: 1160px;
+}
+
+.floormap-section,
+.access-section {
+  margin-bottom: 90px;
+}
+
+.floormap-intro,
+.access-address,
+.access-method-text {
+  color: rgba(241, 250, 238, 0.75);
+  line-height: 1.8;
+}
+
+.floormap-container {
+  position: relative;
+  background: rgba(12, 16, 24, 0.92);
+  border-radius: 24px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.floormap-image {
+  display: block;
+  width: 100%;
+  max-height: 520px;
+  object-fit: cover;
+  transition: transform 0.4s ease, filter 0.4s ease;
+}
+
+.floormap-image.is-zoomed {
+  transform: scale(1.15);
+  filter: brightness(1.08);
+}
+
+.floormap-toolbar {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  display: flex;
+  gap: 12px;
+  z-index: 2;
+}
+
+.floormap-toolbar-button {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: rgba(4, 7, 12, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--accent);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.floormap-toolbar-button:hover,
+.floormap-toolbar-button:focus {
+  background: rgba(230, 57, 70, 0.85);
+  color: var(--light);
+}
+
+.floormap-details {
+  padding: 34px 40px 40px;
+  display: grid;
+  gap: 26px;
+}
+
+.floormap-details-title {
+  font-size: 1.6rem;
+  letter-spacing: 0.1em;
+}
+
+.floormap-details-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.floormap-detail-item {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 18px;
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.floormap-detail-item:hover,
+.floormap-detail-item.is-highlighted {
+  transform: translateY(-4px);
+  border-color: rgba(230, 57, 70, 0.4);
+}
+
+.floormap-detail-title {
+  font-size: 1.1rem;
+  margin-bottom: 12px;
+  letter-spacing: 0.08em;
+}
+
+.floormap-detail-list {
+  list-style: none;
+  display: grid;
+  gap: 8px;
+  color: rgba(241, 250, 238, 0.75);
+}
+
+.floormap-detail-list li {
+  position: relative;
+  padding-left: 16px;
+}
+
+.floormap-detail-list li::before {
+  content: '\2022';
+  position: absolute;
+  left: 0;
+  color: var(--primary);
+}
+
+.access-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 32px;
+  align-items: stretch;
+}
+
+.access-map iframe {
+  width: 100%;
+  min-height: 400px;
+  border-radius: 24px;
+  border: 0;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+}
+
+.access-info {
+  background: rgba(12, 16, 24, 0.92);
+  border-radius: 24px;
+  padding: 32px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: grid;
+  gap: 18px;
+}
+
+.access-subtitle {
+  letter-spacing: 0.3em;
+  color: rgba(241, 250, 238, 0.6);
+}
+
+.access-title {
+  font-size: 2rem;
+}
+
+.access-address {
+  font-size: 1rem;
+}
+
+.access-methods {
+  display: grid;
+  gap: 18px;
+}
+
+.access-method {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 18px;
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.access-method-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 1.05rem;
+  letter-spacing: 0.08em;
+}
+
+.access-method-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: rgba(230, 57, 70, 0.2);
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+}
+
+.access-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-start;
+}
+
+.access-copy-confirmation {
+  display: none;
+  font-size: 0.9rem;
+  color: rgba(241, 250, 238, 0.7);
+}
+
+.access-copy-confirmation.is-visible {
+  display: inline-block;
+}
+
+@media (max-width: 768px) {
+  .floormap-details {
+    padding: 26px;
+  }
+
+  .access-info {
+    padding: 26px;
+  }
+}
+
+@media (max-width: 640px) {
+  .floormap-details-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/css/system-pricing.css
+++ b/css/system-pricing.css
@@ -1,0 +1,303 @@
+/*
+ * Styles for the System & Pricing page template.
+ * Provides layout, tab navigation, pricing tables and FAQ presentation.
+ */
+
+.page-header {
+  background: linear-gradient(135deg, rgba(230, 57, 70, 0.85), rgba(29, 53, 87, 0.85)), url('../assets/images/bg-dark.jpg') center/cover no-repeat;
+  padding: 120px 0 80px;
+  text-align: center;
+}
+
+.page-header-content {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.page-title {
+  font-size: clamp(2.4rem, 4vw, 3.5rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 20px;
+}
+
+.page-subtitle {
+  font-size: 1.05rem;
+  color: rgba(241, 250, 238, 0.9);
+  line-height: 1.8;
+}
+
+.main-content {
+  background-color: #0b0c10;
+  padding: 100px 0;
+}
+
+.content-container {
+  max-width: 1100px;
+}
+
+.intro-text {
+  font-size: 1.1rem;
+  color: rgba(241, 250, 238, 0.85);
+  margin-bottom: 60px;
+  line-height: 1.9;
+}
+
+.pricing-section {
+  margin-bottom: 80px;
+  background: rgba(17, 22, 32, 0.75);
+  border-radius: 24px;
+  padding: 48px;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+}
+
+.pricing-tabs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.pricing-tab {
+  padding: 18px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--accent);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-align: center;
+  cursor: pointer;
+  transition: var(--transition);
+  border: 1px solid transparent;
+}
+
+.pricing-tab:hover,
+.pricing-tab:focus {
+  border-color: rgba(230, 57, 70, 0.6);
+  box-shadow: 0 0 0 3px rgba(230, 57, 70, 0.15);
+}
+
+.pricing-tab.active {
+  background: var(--primary);
+  color: var(--light);
+  transform: translateY(-2px);
+}
+
+.pricing-content {
+  display: none;
+  animation: fadeIn 0.45s ease;
+}
+
+.pricing-content.active {
+  display: block;
+}
+
+.pricing-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(5, 7, 12, 0.7);
+  border-radius: 18px;
+  overflow: hidden;
+}
+
+.pricing-table th,
+.pricing-table td {
+  padding: 18px 22px;
+  text-align: left;
+}
+
+.pricing-table thead {
+  background: rgba(255, 255, 255, 0.08);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.9rem;
+}
+
+.pricing-table tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.price {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.price-accent {
+  color: var(--primary);
+}
+
+.pricing-note {
+  margin-top: 18px;
+  font-size: 0.95rem;
+  color: rgba(241, 250, 238, 0.65);
+}
+
+.system-section {
+  margin-bottom: 80px;
+}
+
+.system-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.system-card {
+  background: rgba(17, 22, 32, 0.85);
+  border-radius: 20px;
+  padding: 28px;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.system-card::after {
+  content: '';
+  position: absolute;
+  top: -40%;
+  right: -40%;
+  width: 220px;
+  height: 220px;
+  background: radial-gradient(circle at center, rgba(230, 57, 70, 0.35), transparent 70%);
+  transition: opacity 0.35s ease;
+  opacity: 0;
+}
+
+.system-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 25px 45px rgba(0, 0, 0, 0.4);
+}
+
+.system-card:hover::after {
+  opacity: 1;
+}
+
+.system-icon {
+  width: 56px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 14px;
+  background: rgba(230, 57, 70, 0.18);
+  color: var(--accent);
+  font-size: 1.4rem;
+  margin-bottom: 18px;
+}
+
+.system-title {
+  font-size: 1.35rem;
+  margin-bottom: 14px;
+}
+
+.system-text {
+  color: rgba(241, 250, 238, 0.75);
+  line-height: 1.8;
+}
+
+.faq-section {
+  margin-bottom: 80px;
+}
+
+.faq-list {
+  display: grid;
+  gap: 18px;
+}
+
+.faq-item {
+  background: rgba(17, 22, 32, 0.85);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+}
+
+.faq-question {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 26px;
+  font-size: 1.05rem;
+  cursor: pointer;
+}
+
+.faq-question span:first-child {
+  flex: 1;
+  margin-right: 16px;
+}
+
+.faq-answer {
+  display: none;
+  background: rgba(10, 12, 18, 0.75);
+}
+
+.faq-answer-inner,
+.faq-answer p {
+  padding: 0 26px 24px;
+  color: rgba(241, 250, 238, 0.75);
+  line-height: 1.8;
+}
+
+.faq-item.active .faq-icon i {
+  transform: rotate(45deg);
+}
+
+.faq-icon i {
+  transition: transform 0.3s ease;
+}
+
+.contact-cta {
+  background: linear-gradient(120deg, rgba(29, 53, 87, 0.95), rgba(230, 57, 70, 0.75));
+  border-radius: 26px;
+  padding: 48px;
+  text-align: center;
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.5);
+}
+
+.cta-title {
+  font-size: clamp(2rem, 3.2vw, 2.8rem);
+  letter-spacing: 0.16em;
+  margin-bottom: 16px;
+}
+
+.cta-text {
+  font-size: 1.05rem;
+  color: rgba(241, 250, 238, 0.8);
+  margin-bottom: 28px;
+  line-height: 1.9;
+}
+
+.cta-buttons {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  .pricing-section {
+    padding: 32px 20px;
+  }
+
+  .pricing-table th,
+  .pricing-table td {
+    padding: 14px 16px;
+  }
+
+  .contact-cta {
+    padding: 36px 24px;
+  }
+}

--- a/js/about-page.js
+++ b/js/about-page.js
@@ -1,0 +1,96 @@
+/**
+ * Enhancements for the About page template.
+ */
+
+jQuery(function ($) {
+  'use strict';
+
+  initScrollAnimations();
+  initTimelineAccessibility();
+  initSmoothAnchors();
+
+  /**
+   * Apply intersection observer to feature cards and timeline items.
+   */
+  function initScrollAnimations() {
+    const $animatedItems = $('.feature-card, .timeline-item');
+
+    if (!$animatedItems.length) {
+      return;
+    }
+
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (prefersReducedMotion) {
+      $animatedItems.addClass('is-visible');
+      return;
+    }
+
+    const observer = new IntersectionObserver(function (entries, observerRef) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          $(entry.target).addClass('is-visible');
+          observerRef.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.2, rootMargin: '0px 0px -10%' });
+
+    $animatedItems.each(function () {
+      observer.observe(this);
+    });
+  }
+
+  /**
+   * Provide keyboard accessibility to the timeline blocks.
+   */
+  function initTimelineAccessibility() {
+    const $timelineItems = $('.timeline-item');
+
+    if (!$timelineItems.length) {
+      return;
+    }
+
+    $timelineItems.attr({ tabindex: 0, role: 'listitem', 'aria-expanded': 'false' });
+
+    $timelineItems.on('keydown', function (event) {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        toggleExpanded($(this));
+      }
+    });
+
+    $timelineItems.on('click', function () {
+      toggleExpanded($(this));
+    });
+  }
+
+  /**
+   * Toggle expanded state for a timeline entry.
+   */
+  function toggleExpanded($item) {
+    const isExpanded = $item.attr('aria-expanded') === 'true';
+    const newState = !isExpanded;
+
+    $item.attr('aria-expanded', newState);
+    $item.toggleClass('is-expanded', newState);
+  }
+
+  /**
+   * Smooth scroll for in-page anchor links (if any).
+   */
+  function initSmoothAnchors() {
+    $('a[href^="#"]').on('click', function (event) {
+      const targetId = $(this).attr('href');
+      if (!targetId || targetId === '#') {
+        return;
+      }
+
+      const $target = $(targetId);
+
+      if ($target.length) {
+        event.preventDefault();
+        $('html, body').animate({ scrollTop: $target.offset().top - 80 }, 500);
+      }
+    });
+  }
+});

--- a/js/customizer.js
+++ b/js/customizer.js
@@ -1,0 +1,30 @@
+/**
+ * Theme Customizer enhancements for a better user experience.
+ */
+
+(function ($) {
+  'use strict';
+
+  if (typeof wp === 'undefined' || !wp.customize) {
+    return;
+  }
+
+  wp.customize('blogname', function (value) {
+    value.bind(function (newValue) {
+      $('.site-title a').text(newValue);
+    });
+  });
+
+  wp.customize('blogdescription', function (value) {
+    value.bind(function (newValue) {
+      $('.site-description').text(newValue);
+    });
+  });
+
+  wp.customize('header_textcolor', function (value) {
+    value.bind(function (color) {
+      const cssColor = color === 'blank' ? 'transparent' : color;
+      $('.site-title a, .site-description').css('color', cssColor);
+    });
+  });
+})(jQuery);

--- a/js/equipment-page.js
+++ b/js/equipment-page.js
@@ -1,0 +1,233 @@
+/**
+ * Interactions for the Equipment list page.
+ */
+
+jQuery(function ($) {
+  'use strict';
+
+  const $tabs = $('.equipment-tab');
+  const $contents = $('.equipment-content');
+  const $cards = $('.equipment-card');
+  const $searchInput = $('.equipment-search input');
+  const $exportButton = $('.equipment-export');
+  const $tools = $('.equipment-tools');
+  const $noResults = $('<div class="no-results-message equipment-no-results" style="display:none;">該当する機材が見つかりません。</div>');
+  const $exportStatus = $('<span class="equipment-export-status" role="status" aria-live="polite"></span>');
+  let exportMessageTimeout = null;
+
+  if ($tools.length) {
+    $tools.after($noResults);
+    $tools.append($exportStatus);
+  }
+
+  initTabs();
+  initSearch();
+  initExport();
+  filterEquipment();
+
+  /**
+   * Initialise tab switching behaviour.
+   */
+  function initTabs() {
+    $tabs.each(function (index) {
+      const $tab = $(this);
+      const target = $tab.data('tab');
+      const panelId = `${target}-content`;
+      const tabId = `equipment-tab-${index}`;
+
+      $tab.attr({
+        id: tabId,
+        role: 'tab',
+        tabindex: $tab.hasClass('active') ? 0 : -1,
+        'aria-controls': panelId,
+        'aria-selected': $tab.hasClass('active')
+      });
+
+      $contents.filter(`#${panelId}`).attr({
+        role: 'tabpanel',
+        'aria-labelledby': tabId,
+        hidden: !$tab.hasClass('active')
+      });
+
+      $tab.on('click', function () {
+        activateTab($tab);
+      });
+
+      $tab.on('keydown', function (event) {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          activateTab($tab);
+        }
+      });
+    });
+  }
+
+  /**
+   * Activate a specific equipment tab.
+   */
+  function activateTab($tab) {
+    const target = $tab.data('tab');
+
+    $tabs.removeClass('active').attr({
+      'aria-selected': 'false',
+      tabindex: -1
+    });
+
+    $contents.removeClass('active').attr('hidden', true);
+
+    $tab.addClass('active').attr({
+      'aria-selected': 'true',
+      tabindex: 0
+    }).focus();
+
+    $contents.filter(`#${target}-content`).addClass('active').attr('hidden', false);
+    filterEquipment();
+  }
+
+  /**
+   * Initialise equipment search filtering.
+   */
+  function initSearch() {
+    if (!$searchInput.length) {
+      return;
+    }
+
+    $searchInput.on('input', function () {
+      filterEquipment();
+    });
+  }
+
+  /**
+   * Filter equipment cards based on search input.
+   */
+  function filterEquipment() {
+    const term = $searchInput.length ? $searchInput.val().trim().toLowerCase() : '';
+    const $activeContent = $contents.filter('.active');
+    let visibleCount = 0;
+
+    $cards.each(function () {
+      const $card = $(this);
+      const matches = !term || $card.text().toLowerCase().includes(term);
+
+      $card.toggle(matches);
+      $card.toggleClass('equipment-highlight', matches && term.length >= 2);
+    });
+
+    if ($activeContent.length) {
+      visibleCount = $activeContent.find('.equipment-card:visible').length;
+    } else {
+      visibleCount = $('.equipment-card:visible').length;
+    }
+
+    if (term && visibleCount === 0) {
+      $noResults.show();
+    } else {
+      $noResults.hide();
+    }
+  }
+
+  /**
+   * Initialise export button behaviour (copy visible items to clipboard).
+   */
+  function initExport() {
+    if (!$exportButton.length) {
+      return;
+    }
+
+    $exportButton.on('click', function (event) {
+      event.preventDefault();
+
+      const exportText = buildExportText();
+
+      copyToClipboard(exportText)
+        .then(function () {
+          showExportMessage('機材リストをコピーしました。');
+        })
+        .catch(function () {
+          showExportMessage('コピーに失敗しました。', true);
+        });
+    });
+  }
+
+  /**
+   * Create export text from visible equipment cards.
+   */
+  function buildExportText() {
+    const lines = [];
+    const $activeCards = $('.equipment-content.active .equipment-card:visible');
+    const $targetCards = $activeCards.length ? $activeCards : $('.equipment-card:visible');
+
+    $targetCards.each(function () {
+      const $card = $(this);
+      const title = $card.find('.equipment-title').text().trim();
+      const items = $card.find('.equipment-list .equipment-item').map(function () {
+        return ` - ${$(this).text().trim()}`;
+      }).get();
+
+      lines.push(title);
+      lines.push(...items);
+      lines.push('');
+    });
+
+    if (!lines.length) {
+      lines.push('Logic Nagoya Equipment List');
+    }
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Copy helper supporting browsers without navigator.clipboard.
+   */
+  function copyToClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+
+    return new Promise(function (resolve, reject) {
+      const textarea = $('<textarea style="position:absolute;left:-9999px;top:-9999px;"></textarea>');
+      textarea.val(text);
+      $('body').append(textarea);
+      textarea[0].select();
+
+      try {
+        const successful = document.execCommand('copy');
+        textarea.remove();
+        if (successful) {
+          resolve();
+        } else {
+          reject(new Error('Copy command unsuccessful'));
+        }
+      } catch (error) {
+        textarea.remove();
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Display export status message.
+   */
+  function showExportMessage(message, isError) {
+    if (!$exportStatus.length) {
+      return;
+    }
+
+    $exportStatus.text(message);
+    $exportStatus.toggleClass('is-visible', true);
+
+    if (isError) {
+      $exportStatus.css('color', '#f7b267');
+    } else {
+      $exportStatus.css('color', 'rgba(241, 250, 238, 0.65)');
+    }
+
+    if (exportMessageTimeout) {
+      clearTimeout(exportMessageTimeout);
+    }
+
+    exportMessageTimeout = setTimeout(function () {
+      $exportStatus.removeClass('is-visible').text('');
+    }, 4000);
+  }
+});

--- a/js/events-page.js
+++ b/js/events-page.js
@@ -1,0 +1,521 @@
+/**
+ * Interactions for the Events page: tab switching, filtering, calendar rendering and modal details.
+ */
+
+jQuery(function ($) {
+  'use strict';
+
+  const $navItems = $('.events-nav-item');
+  const $listView = $('#list-view');
+  const $calendarView = $('#calendar-view');
+  const $calendarBody = $('#calendar-body');
+  const $calendarTitle = $('#calendar-title');
+  const $eventGrid = $('.event-grid');
+  const $cards = $eventGrid.find('.event-card');
+  const $categoryFilter = $('#category-filter');
+  const $sortFilter = $('#sort-filter');
+  const $searchForm = $('#event-search-form');
+  const $searchInput = $searchForm.find('.search-input');
+  const $noEventsMessage = $('<div class="no-events-message" style="display:none;">現在表示できるイベントがありません。</div>');
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  if ($eventGrid.length) {
+    $eventGrid.after($noEventsMessage);
+  }
+
+  const state = {
+    mode: 'list',
+    category: 'all',
+    sort: 'date-desc',
+    search: ''
+  };
+
+  const eventsData = buildEventDataset();
+
+  let calendarReferenceDate = new Date(today.getFullYear(), today.getMonth(), 1);
+  renderCalendar();
+
+  attachNavEvents();
+  attachFilterEvents();
+  attachModalEvents();
+
+  applyFilters();
+
+  /**
+   * Build an array of event metadata sourced from the DOM.
+   */
+  function buildEventDataset() {
+    const dataset = [];
+
+    $cards.each(function (index) {
+      const $card = $(this);
+      const title = $card.find('.event-title').text().trim();
+      const dateText = $card.find('.event-date-badge').text().trim();
+      const timeText = extractDetail($card, 'clock');
+      const priceText = extractDetail($card, 'ticket');
+      const categoryText = $card.find('.event-category').text().trim();
+      const descriptionHtml = $card.find('.event-description').length ? $card.find('.event-description').html().trim() : '';
+      const image = $card.find('.event-image img');
+      const imageSrc = image.attr('src') || '';
+      const imageAlt = image.attr('alt') || title;
+      const link = $card.find('.event-btn').attr('href') || '';
+      const descriptionText = $('<div>').html(descriptionHtml).text().trim();
+      const performersHtml = $card.find('.event-performers').length ? $card.find('.event-performers').html().trim() : ($card.data('performers') || '');
+      const categorySlug = slugify(categoryText) || 'uncategorized';
+      const date = parseEventDate(dateText);
+      const timestamp = date ? date.getTime() : null;
+      const searchHaystack = [title, descriptionText, timeText, priceText, categoryText].join(' ').toLowerCase();
+
+      const eventData = {
+        id: index,
+        $card,
+        title,
+        dateText,
+        date,
+        timestamp,
+        time: timeText,
+        price: priceText,
+        category: categoryText,
+        categorySlug,
+        descriptionHtml,
+        imageSrc,
+        imageAlt,
+        link,
+        performers: performersHtml,
+        searchHaystack
+      };
+
+      $card.attr({
+        'data-category': categorySlug,
+        'data-event-id': index
+      });
+
+      $card.data('event', eventData);
+      dataset.push(eventData);
+    });
+
+    return dataset;
+  }
+
+  /**
+   * Extract a detail value from the event info rows by icon name.
+   */
+  function extractDetail($card, iconKeyword) {
+    let value = '';
+
+    $card.find('.event-info').each(function () {
+      const $info = $(this);
+      const iconClass = $info.find('i').attr('class') || '';
+      if (iconClass.includes(iconKeyword)) {
+        value = $info.find('span').text().trim();
+        return false;
+      }
+
+      // Fallback if there is no span element
+      const text = $info.clone().children('i').remove().end().text().trim();
+      if (!value && text && iconKeyword === 'clock') {
+        value = text;
+      }
+    });
+
+    return value;
+  }
+
+  /**
+   * Convert string to slug.
+   */
+  function slugify(str) {
+    if (!str) {
+      return '';
+    }
+
+    return str
+      .toString()
+      .toLowerCase()
+      .replace(/\s+/g, '-')
+      .replace(/[^a-z0-9\-]+/g, '')
+      .replace(/\-+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  /**
+   * Parse event date string into Date object.
+   */
+  function parseEventDate(value) {
+    if (!value) {
+      return null;
+    }
+
+    let text = value.trim();
+    text = text.replace(/[年月]/g, '-').replace(/日/g, '').replace(/[\.\/]/g, '-');
+    const digits = text.match(/(\d{4})-?(\d{1,2})-?(\d{1,2})/);
+
+    if (!digits) {
+      return null;
+    }
+
+    const year = parseInt(digits[1], 10);
+    const month = parseInt(digits[2], 10);
+    const day = parseInt(digits[3], 10);
+
+    if (!year || !month || !day) {
+      return null;
+    }
+
+    return new Date(year, month - 1, day);
+  }
+
+  /**
+   * Apply current filters and sorting to the event list.
+   */
+  function applyFilters() {
+    sortCards();
+
+    let visibleCount = 0;
+
+    $cards.each(function () {
+      const $card = $(this);
+      const data = $card.data('event');
+      let isVisible = true;
+
+      if (!data) {
+        return;
+      }
+
+      if (state.category !== 'all' && data.categorySlug !== state.category) {
+        isVisible = false;
+      }
+
+      if (state.mode === 'upcoming' && data.timestamp !== null) {
+        isVisible = data.timestamp >= today.getTime();
+      }
+
+      if (state.mode === 'past') {
+        isVisible = data.timestamp !== null && data.timestamp < today.getTime();
+      }
+
+      if (state.search) {
+        isVisible = isVisible && data.searchHaystack.includes(state.search);
+      }
+
+      $card.toggleClass('is-hidden', !isVisible);
+
+      if (isVisible) {
+        visibleCount += 1;
+      }
+    });
+
+    if (visibleCount === 0) {
+      $noEventsMessage.show();
+    } else {
+      $noEventsMessage.hide();
+    }
+  }
+
+  /**
+   * Sort event cards based on the selected ordering.
+   */
+  function sortCards() {
+    const sortedCards = $cards.get().sort(function (a, b) {
+      const dataA = $(a).data('event');
+      const dataB = $(b).data('event');
+
+      if (!dataA || !dataB) {
+        return 0;
+      }
+
+      switch (state.sort) {
+        case 'date-asc':
+          return compareTimestamp(dataA, dataB);
+        case 'date-desc':
+          return compareTimestamp(dataB, dataA);
+        case 'name-desc':
+          return dataB.title.localeCompare(dataA.title, 'ja');
+        case 'name-asc':
+        default:
+          return dataA.title.localeCompare(dataB.title, 'ja');
+      }
+    });
+
+    $.each(sortedCards, function (_, card) {
+      $eventGrid.append(card);
+    });
+  }
+
+  /**
+   * Compare helper respecting missing timestamps.
+   */
+  function compareTimestamp(a, b) {
+    if (a.timestamp === null && b.timestamp === null) {
+      return 0;
+    }
+    if (a.timestamp === null) {
+      return 1;
+    }
+    if (b.timestamp === null) {
+      return -1;
+    }
+    return a.timestamp - b.timestamp;
+  }
+
+  /**
+   * Attach navigation interactions.
+   */
+  function attachNavEvents() {
+    $navItems.each(function () {
+      const $item = $(this);
+      const view = $item.data('view');
+
+      $item.attr({
+        role: 'tab',
+        tabindex: $item.hasClass('active') ? 0 : -1,
+        'aria-selected': $item.hasClass('active')
+      });
+
+      $item.on('click', function () {
+        activateView(view, $item);
+      });
+
+      $item.on('keydown', function (event) {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          activateView(view, $item);
+        }
+      });
+    });
+  }
+
+  /**
+   * Activate view (list/calendar/upcoming/past).
+   */
+  function activateView(view, $item) {
+    $navItems.removeClass('active').attr({
+      'aria-selected': 'false',
+      tabindex: -1
+    });
+
+    $item.addClass('active').attr({
+      'aria-selected': 'true',
+      tabindex: 0
+    }).focus();
+
+    if (view === 'calendar') {
+      $calendarView.addClass('active');
+      $listView.removeClass('active');
+      renderCalendar();
+      return;
+    }
+
+    $calendarView.removeClass('active');
+    $listView.addClass('active');
+
+    if (view === 'upcoming' || view === 'past') {
+      state.mode = view;
+    } else {
+      state.mode = 'list';
+    }
+
+    applyFilters();
+  }
+
+  /**
+   * Attach form / dropdown filters.
+   */
+  function attachFilterEvents() {
+    $categoryFilter.on('change', function () {
+      state.category = $(this).val();
+      applyFilters();
+    });
+
+    $sortFilter.on('change', function () {
+      state.sort = $(this).val();
+      applyFilters();
+    });
+
+    $searchForm.on('submit', function (event) {
+      event.preventDefault();
+    });
+
+    $searchInput.on('input', function () {
+      state.search = $(this).val().trim().toLowerCase();
+      applyFilters();
+    });
+
+    $('#prev-month').on('click', function () {
+      calendarReferenceDate.setMonth(calendarReferenceDate.getMonth() - 1);
+      renderCalendar();
+    });
+
+    $('#next-month').on('click', function () {
+      calendarReferenceDate.setMonth(calendarReferenceDate.getMonth() + 1);
+      renderCalendar();
+    });
+  }
+
+  /**
+   * Render monthly calendar view based on events dataset.
+   */
+  function renderCalendar() {
+    if (!$calendarBody.length) {
+      return;
+    }
+
+    const year = calendarReferenceDate.getFullYear();
+    const month = calendarReferenceDate.getMonth();
+    const firstDay = new Date(year, month, 1);
+    const startWeekday = firstDay.getDay();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+    $calendarTitle.text(`${year}年${month + 1}月`);
+    $calendarBody.empty();
+
+    let day = 1;
+
+    for (let row = 0; row < 6; row += 1) {
+      const $tr = $('<tr></tr>');
+
+      for (let col = 0; col < 7; col += 1) {
+        const cellIndex = row * 7 + col;
+        const $td = $('<td></td>');
+        const $dayContainer = $('<div class="calendar-day"></div>');
+
+        if (cellIndex >= startWeekday && day <= daysInMonth) {
+          const cellDate = new Date(year, month, day);
+          $dayContainer.append(`<div class="calendar-day-number">${day}</div>`);
+
+          const eventsForDay = eventsData.filter(function (event) {
+            if (!event.date) {
+              return false;
+            }
+
+            return event.date.getFullYear() === cellDate.getFullYear() &&
+              event.date.getMonth() === cellDate.getMonth() &&
+              event.date.getDate() === cellDate.getDate();
+          });
+
+          if (eventsForDay.length) {
+            $dayContainer.addClass('has-event');
+            eventsForDay.slice(0, 2).forEach(function (event) {
+              const label = $('<div class="calendar-event"></div>').text(event.title);
+              label.attr('data-event-id', event.id);
+              $dayContainer.append(label);
+            });
+          }
+
+          day += 1;
+        }
+
+        $td.append($dayContainer);
+        $tr.append($td);
+      }
+
+      $calendarBody.append($tr);
+    }
+  }
+
+  /**
+   * Attach modal open/close events.
+   */
+  function attachModalEvents() {
+    const $modal = $('#event-modal');
+
+    if (!$modal.length) {
+      return;
+    }
+
+    const $close = $modal.find('.modal-close');
+    const $ticketLink = $('#modal-ticket-link');
+
+    $ticketLink.attr({ target: '_blank', rel: 'noopener noreferrer' });
+    $('#share-twitter, #share-facebook, #share-line').attr({ target: '_blank', rel: 'noopener noreferrer' });
+
+    $eventGrid.on('click', '.event-btn', function (event) {
+      event.preventDefault();
+      const $card = $(this).closest('.event-card');
+      const data = $card.data('event');
+      openModal(data);
+    });
+
+    $modal.on('click', function (event) {
+      if ($(event.target).is($modal)) {
+        closeModal();
+      }
+    });
+
+    $close.on('click', function () {
+      closeModal();
+    });
+
+    $(document).on('keydown', function (event) {
+      if (event.key === 'Escape' && $modal.hasClass('active')) {
+        closeModal();
+      }
+    });
+  }
+
+  /**
+   * Open modal with event information.
+   */
+  function openModal(data) {
+    if (!data) {
+      return;
+    }
+
+    $('#modal-img').attr({ src: data.imageSrc, alt: data.imageAlt || data.title });
+    $('#modal-title').text(data.title || '');
+    $('#modal-date').text(data.dateText || '未定');
+    $('#modal-time').text(data.time || '未定');
+    $('#modal-category').text(data.category || '');
+    $('#modal-description').html(data.descriptionHtml || '<p>詳細情報は近日公開予定です。</p>');
+
+    if (data.price) {
+      $('#modal-tickets').html(`<div class="ticket-option"><span>${data.price}</span><span>Logic Nagoya</span></div>`);
+    } else {
+      $('#modal-tickets').html('<p>チケット情報はお問い合わせください。</p>');
+    }
+
+    $('#modal-performers-section').toggle(!!data.performers);
+
+    if (data.performers) {
+      $('#modal-performers').html(data.performers);
+    } else {
+      $('#modal-performers').empty();
+    }
+
+    const ticketLink = data.link || '';
+    const $ticketLink = $('#modal-ticket-link');
+
+    if (ticketLink) {
+      $ticketLink.attr('href', ticketLink).removeClass('is-disabled');
+    } else {
+      $ticketLink.attr('href', '#').addClass('is-disabled');
+    }
+
+    updateShareLinks(data);
+
+    $('#event-modal').addClass('active');
+    $('body').addClass('modal-open');
+    $('.modal-close').focus();
+  }
+
+  /**
+   * Close modal view.
+   */
+  function closeModal() {
+    $('#event-modal').removeClass('active');
+    $('body').removeClass('modal-open');
+  }
+
+  /**
+   * Update share links for the modal content.
+   */
+  function updateShareLinks(data) {
+    const url = encodeURIComponent(data.link || window.location.href);
+    const text = encodeURIComponent(`${data.title} | Logic Nagoya`);
+
+    $('#share-twitter').attr('href', `https://twitter.com/intent/tweet?text=${text}&url=${url}`);
+    $('#share-facebook').attr('href', `https://www.facebook.com/sharer/sharer.php?u=${url}`);
+    $('#share-line').attr('href', `https://social-plugins.line.me/lineit/share?url=${url}`);
+  }
+});

--- a/js/floor-map-page.js
+++ b/js/floor-map-page.js
@@ -1,0 +1,143 @@
+/**
+ * Enhancements for the Floor map & Access page.
+ */
+
+jQuery(function ($) {
+  'use strict';
+
+  initFloorMapToolbar();
+  initDetailHighlights();
+  initAddressCopy();
+
+  /**
+   * Create toolbar controls for the floor map image.
+   */
+  function initFloorMapToolbar() {
+    const $image = $('#floormap-img');
+    const $container = $image.closest('.floormap-container');
+
+    if (!$image.length || !$container.length) {
+      return;
+    }
+
+    const $toolbar = $('<div class="floormap-toolbar" role="group" aria-label="フロアマップ操作"></div>');
+    const $zoomButton = $('<button type="button" class="floormap-toolbar-button" aria-pressed="false" aria-label="フロアマップを拡大"><i class="fas fa-search-plus"></i></button>');
+    const $resetButton = $('<button type="button" class="floormap-toolbar-button" aria-label="拡大をリセット"><i class="fas fa-sync-alt"></i></button>');
+    const $downloadButton = $('<a class="floormap-toolbar-button" aria-label="フロアマップを新しいタブで開く" target="_blank" rel="noopener"><i class="fas fa-external-link-alt"></i></a>');
+
+    $downloadButton.attr('href', $image.attr('src'));
+
+    $toolbar.append($zoomButton, $resetButton, $downloadButton);
+    $container.append($toolbar);
+
+    $zoomButton.on('click', function () {
+      const isZoomed = $image.toggleClass('is-zoomed').hasClass('is-zoomed');
+      $zoomButton.attr('aria-pressed', isZoomed);
+    });
+
+    $resetButton.on('click', function () {
+      $image.removeClass('is-zoomed');
+      $zoomButton.attr('aria-pressed', 'false');
+    });
+
+    $image.on('dblclick', function () {
+      $zoomButton.trigger('click');
+    });
+  }
+
+  /**
+   * Highlight detail blocks on hover/focus to improve readability.
+   */
+  function initDetailHighlights() {
+    const $detailItems = $('.floormap-detail-item');
+
+    if (!$detailItems.length) {
+      return;
+    }
+
+    $detailItems.attr('tabindex', 0);
+
+    $detailItems.on('mouseenter focusin', function () {
+      $(this).addClass('is-highlighted');
+    });
+
+    $detailItems.on('mouseleave focusout', function () {
+      $(this).removeClass('is-highlighted');
+    });
+  }
+
+  /**
+   * Provide copy-to-clipboard button for the access address.
+   */
+  function initAddressCopy() {
+    const $address = $('.access-address');
+
+    if (!$address.length) {
+      return;
+    }
+
+    const addressText = $('<div>').html($address.html()).text().replace(/\s+/g, ' ').trim();
+    const $cta = $('<div class="access-cta"></div>');
+    const $copyButton = $('<button type="button" class="btn btn-outline"><i class="fas fa-copy" aria-hidden="true"></i> <span>住所をコピー</span></button>');
+    const $confirmation = $('<span class="access-copy-confirmation" role="status" aria-live="polite"></span>');
+
+    $cta.append($copyButton, $confirmation);
+    $address.after($cta);
+
+    $copyButton.on('click', function () {
+      copyToClipboard(addressText)
+        .then(function () {
+          showCopyMessage($confirmation, '住所をコピーしました。');
+        })
+        .catch(function () {
+          showCopyMessage($confirmation, 'コピーに失敗しました。', true);
+        });
+    });
+  }
+
+  /**
+   * Copy helper supporting navigator.clipboard fallback.
+   */
+  function copyToClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+
+    return new Promise(function (resolve, reject) {
+      const textarea = $('<textarea style="position:absolute;left:-9999px;top:-9999px;"></textarea>');
+      textarea.val(text);
+      $('body').append(textarea);
+      textarea[0].select();
+
+      try {
+        const successful = document.execCommand('copy');
+        textarea.remove();
+        if (successful) {
+          resolve();
+        } else {
+          reject(new Error('Copy failed'));
+        }
+      } catch (error) {
+        textarea.remove();
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Show confirmation message below the address.
+   */
+  function showCopyMessage($element, message, isError) {
+    $element.text(message).addClass('is-visible');
+
+    if (isError) {
+      $element.css('color', '#f7b267');
+    } else {
+      $element.css('color', 'rgba(241, 250, 238, 0.7)');
+    }
+
+    setTimeout(function () {
+      $element.removeClass('is-visible').text('');
+    }, 4000);
+  }
+});

--- a/js/lazy-loading.js
+++ b/js/lazy-loading.js
@@ -1,0 +1,112 @@
+/**
+ * Lazy loading utility for images, iframes and videos.
+ */
+
+(function () {
+  'use strict';
+
+  const lazySelectors = 'img[data-src], img[data-srcset], iframe[data-src], video[data-src], source[data-srcset]';
+  const elements = [].slice.call(document.querySelectorAll(lazySelectors));
+
+  if (!elements.length) {
+    return;
+  }
+
+  if ('loading' in HTMLImageElement.prototype) {
+    elements.forEach(applyNativeLazyLoading);
+  } else if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver(onIntersection, {
+      rootMargin: '150px 0px',
+      threshold: 0.01
+    });
+
+    elements.forEach(function (element) {
+      observer.observe(element);
+    });
+  } else {
+    // Fallback for older browsers
+    loadAllElements();
+  }
+
+  /**
+   * Intersection observer callback.
+   */
+  function onIntersection(entries, observer) {
+    entries.forEach(function (entry) {
+      if (entry.isIntersecting || entry.intersectionRatio > 0) {
+        loadElement(entry.target);
+        observer.unobserve(entry.target);
+      }
+    });
+  }
+
+  /**
+   * Load every element immediately.
+   */
+  function loadAllElements() {
+    elements.forEach(loadElement);
+  }
+
+  /**
+   * Apply native lazy loading attribute for supporting browsers.
+   */
+  function applyNativeLazyLoading(element) {
+    if ('loading' in element) {
+      element.loading = 'lazy';
+    }
+    loadElement(element);
+  }
+
+  /**
+   * Load an element by swapping dataset attributes.
+   */
+  function loadElement(element) {
+    const node = element;
+
+    if (!node) {
+      return;
+    }
+
+    const markLoaded = function () {
+      if (node.parentElement && node.parentElement.classList) {
+        node.parentElement.classList.add('is-loaded');
+      }
+      node.classList.add('is-loaded');
+    };
+
+    if (node.tagName === 'IMG') {
+      node.addEventListener('load', markLoaded, { once: true });
+      node.addEventListener('error', markLoaded, { once: true });
+      if (node.complete) {
+        markLoaded();
+      }
+    }
+
+    if (node.dataset.srcset) {
+      node.setAttribute('srcset', node.dataset.srcset);
+      delete node.dataset.srcset;
+    }
+
+    if (node.dataset.src) {
+      node.setAttribute('src', node.dataset.src);
+      delete node.dataset.src;
+    }
+
+    if (node.dataset.sizes) {
+      node.setAttribute('sizes', node.dataset.sizes);
+      delete node.dataset.sizes;
+    }
+
+    if (node.tagName === 'VIDEO') {
+      node.load();
+    }
+
+    if (node.tagName === 'SOURCE' && node.parentElement && node.parentElement.tagName === 'VIDEO') {
+      node.parentElement.load();
+    }
+
+    if (node.tagName !== 'IMG') {
+      markLoaded();
+    }
+  }
+})();

--- a/js/system-pricing.js
+++ b/js/system-pricing.js
@@ -1,0 +1,175 @@
+/**
+ * Interactions for the System & Pricing page.
+ */
+
+jQuery(function ($) {
+  'use strict';
+
+  const tabs = $('.pricing-tab');
+  const contents = $('.pricing-content');
+
+  if (tabs.length > 0) {
+    initTabs();
+  }
+
+  initFAQ();
+
+  /**
+   * Initialise pricing tab behaviour with ARIA attributes.
+   */
+  function initTabs() {
+    const tablist = $('<div class="pricing-tablist" role="tablist" aria-label="料金プラン"></div>');
+
+    if (!$('.pricing-tabs').attr('role')) {
+      $('.pricing-tabs').attr('role', 'tablist');
+    }
+
+    tabs.each(function (index) {
+      const $tab = $(this);
+      const tabId = `pricing-tab-${index}`;
+      const panelId = `${$tab.data('tab')}-content`;
+
+      $tab.attr({
+        id: tabId,
+        role: 'tab',
+        tabindex: $tab.hasClass('active') ? 0 : -1,
+        'aria-selected': $tab.hasClass('active'),
+        'aria-controls': panelId
+      });
+
+      const $panel = contents.filter(`#${panelId}`);
+
+      $panel.attr({
+        role: 'tabpanel',
+        'aria-labelledby': tabId,
+        hidden: !$tab.hasClass('active')
+      });
+    });
+
+    tabs.on('click', function () {
+      activateTab($(this));
+    });
+
+    tabs.on('keydown', function (event) {
+      const key = event.key;
+      const currentIndex = tabs.index(this);
+      let newIndex = null;
+
+      if (key === 'ArrowRight' || key === 'ArrowDown') {
+        newIndex = (currentIndex + 1) % tabs.length;
+      } else if (key === 'ArrowLeft' || key === 'ArrowUp') {
+        newIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+      } else if (key === 'Home') {
+        newIndex = 0;
+      } else if (key === 'End') {
+        newIndex = tabs.length - 1;
+      }
+
+      if (newIndex !== null) {
+        event.preventDefault();
+        activateTab($(tabs.get(newIndex)));
+      }
+    });
+  }
+
+  /**
+   * Activate a specific tab.
+   *
+   * @param {jQuery} $tab
+   */
+  function activateTab($tab) {
+    const target = $tab.data('tab');
+    const $panel = contents.filter(`#${target}-content`);
+
+    if ($tab.hasClass('active')) {
+      return;
+    }
+
+    tabs.removeClass('active').attr({
+      'aria-selected': 'false',
+      tabindex: -1
+    });
+
+    contents.removeClass('active').attr('hidden', true);
+
+    $tab.addClass('active').attr({
+      'aria-selected': 'true',
+      tabindex: 0
+    }).focus();
+
+    $panel.addClass('active').attr('hidden', false);
+  }
+
+  /**
+   * Initialise FAQ accordion behaviour for this page.
+   */
+  function initFAQ() {
+    const faqItems = $('.faq-item');
+
+    if (!faqItems.length) {
+      return;
+    }
+
+    faqItems.each(function (index) {
+      const $item = $(this);
+      const $question = $item.find('.faq-question');
+      const $answer = $item.find('.faq-answer');
+      const questionId = `pricing-faq-question-${index}`;
+      const answerId = `pricing-faq-answer-${index}`;
+
+      $question.attr({
+        id: questionId,
+        role: 'button',
+        tabindex: 0,
+        'aria-expanded': 'false',
+        'aria-controls': answerId
+      });
+
+      $answer.attr({
+        id: answerId,
+        role: 'region',
+        'aria-labelledby': questionId,
+        hidden: true
+      });
+    });
+
+    $('.faq-question').on('click', function () {
+      toggleFAQ($(this).closest('.faq-item'));
+    });
+
+    $('.faq-question').on('keydown', function (event) {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        toggleFAQ($(this).closest('.faq-item'));
+      }
+    });
+  }
+
+  /**
+   * Toggle FAQ item visibility.
+   *
+   * @param {jQuery} $item
+   */
+  function toggleFAQ($item) {
+    const $answer = $item.find('.faq-answer');
+    const $question = $item.find('.faq-question');
+    const isActive = $item.hasClass('active');
+
+    $('.faq-item').not($item).removeClass('active').find('.faq-answer').slideUp(240).attr('hidden', true);
+    $('.faq-item').not($item).find('.faq-question').attr('aria-expanded', 'false');
+
+    if (isActive) {
+      $item.removeClass('active');
+      $answer.slideUp(240, function () {
+        $answer.attr('hidden', true);
+      });
+      $question.attr('aria-expanded', 'false');
+    } else {
+      $item.addClass('active');
+      $answer.slideDown(240, function () {
+        $answer.attr('hidden', false);
+      });
+      $question.attr('aria-expanded', 'true');
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add dedicated stylesheets for the pricing, events, equipment, about, and floor map templates to match their markup
- implement client-side interactions for each template, including tabs, filters, calendar rendering, modals, and accessibility helpers
- supply shared utilities such as a lazy-loading script and Customizer live preview bindings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d61db3ce5483338943eabe7fd65bb8