### PR TITLE
Use wp_json_encode for structured data output

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -386,7 +386,7 @@ function logic_nagoya_structured_data() {
     foreach ($schema_data as $schema) {
         if (!empty($schema)) {
             echo '<script type="application/ld+json">' . "\n";
-            echo json_encode($schema, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT) . "\n";
+            echo wp_json_encode($schema, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT) . "\n";
             echo '</script>' . "\n";
         }
     }


### PR DESCRIPTION
## Summary
- replace json_encode with wp_json_encode in structured data output to leverage WordPress-specific encoding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d63f154c208333af251d5dc95ebe52