### PR TITLE
Add sitemap query var and flush rewrite rules on theme activation

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -812,8 +812,18 @@ function logic_nagoya_robots_txt($output) {
  */
 function logic_nagoya_sitemap_init() {
     // カスタムサイトマップの生成
+    add_filter('query_vars', 'logic_nagoya_register_sitemap_query_var');
     add_action('init', 'logic_nagoya_sitemap_rewrite_rules');
     add_action('template_redirect', 'logic_nagoya_sitemap_template');
+}
+
+/**
+ * サイトマップ用のクエリ変数登録
+ */
+function logic_nagoya_register_sitemap_query_var($vars) {
+    $vars[] = 'sitemap';
+
+    return $vars;
 }
 
 /**
@@ -823,6 +833,15 @@ function logic_nagoya_sitemap_rewrite_rules() {
     add_rewrite_rule('^sitemap\.xml$', 'index.php?sitemap=main', 'top');
     add_rewrite_rule('^sitemap-([^/]+)\.xml$', 'index.php?sitemap=$matches[1]', 'top');
 }
+
+/**
+ * テーマ有効化時のリライトルール更新
+ */
+function logic_nagoya_flush_rewrite_rules_on_switch() {
+    logic_nagoya_sitemap_rewrite_rules();
+    flush_rewrite_rules();
+}
+add_action('after_switch_theme', 'logic_nagoya_flush_rewrite_rules_on_switch');
 
 /**
  * サイトマップのテンプレート処理


### PR DESCRIPTION
## Summary
- register the sitemap query variable when initializing sitemap support
- flush rewrite rules after theme activation to ensure sitemap rules are available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d790264748833396f3b0376c27f87a