### PR TITLE
Use WordPress date helpers

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -91,7 +91,7 @@
       </div>
       
       <div class="footer-bottom">
-        <p>&copy; <?php echo esc_html( date( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?>. <?php esc_html_e( 'All rights reserved.', 'logic-nagoya' ); ?></p>
+        <p>&copy; <?php echo esc_html( wp_date( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?>. <?php esc_html_e( 'All rights reserved.', 'logic-nagoya' ); ?></p>
       </div>
     </div>
   </footer>

--- a/front-page.php
+++ b/front-page.php
@@ -122,7 +122,7 @@ get_header();
             'meta_query' => array(
                 array(
                     'key' => 'event_date',
-                    'value' => date('Y-m-d'),
+                    'value' => wp_date('Y-m-d'),
                     'compare' => '>=',
                     'type' => 'DATE'
                 )
@@ -137,7 +137,7 @@ get_header();
                 // Get event date
                 $event_date = get_post_meta(get_the_ID(), 'event_date', true);
                 if ($event_date) {
-                    $formatted_date = date_i18n(get_option('date_format'), strtotime($event_date));
+                    $formatted_date = wp_date(get_option('date_format'), strtotime($event_date));
                 } else {
                     $formatted_date = 'Coming Soon';
                 }

--- a/functions.php
+++ b/functions.php
@@ -285,7 +285,7 @@ function logic_nagoya_get_meta_description() {
         $description = 'Logic Nagoyaで開催される「' . get_the_title() . '」';
         
         if ($event_date) {
-            $description .= '（' . date('Y年m月d日', strtotime($event_date)) . '開催）';
+            $description .= '（' . wp_date('Y年m月d日', strtotime($event_date)) . '開催）';
         }
         
         $excerpt = get_the_excerpt();
@@ -554,7 +554,7 @@ function logic_nagoya_event_schema() {
                 'price' => $pricing['price_advance'],
                 'priceCurrency' => 'JPY',
                 'availability' => 'https://schema.org/InStock',
-                'validFrom' => date('Y-m-d')
+                'validFrom' => wp_date('Y-m-d')
             ];
         }
 
@@ -864,25 +864,27 @@ function logic_nagoya_sitemap_template() {
 function logic_nagoya_main_sitemap() {
     echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
     echo '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
-    
+
+    $current_datetime_utc = current_datetime('UTC')->format(DATE_W3C);
+
     // ページサイトマップ
     echo '<sitemap>' . "\n";
     echo '<loc>' . home_url('/sitemap-pages.xml') . '</loc>' . "\n";
-    echo '<lastmod>' . date('Y-m-d\TH:i:s+00:00') . '</lastmod>' . "\n";
+    echo '<lastmod>' . $current_datetime_utc . '</lastmod>' . "\n";
     echo '</sitemap>' . "\n";
 
     // 投稿サイトマップ
     echo '<sitemap>' . "\n";
     echo '<loc>' . home_url('/sitemap-posts.xml') . '</loc>' . "\n";
-    echo '<lastmod>' . date('Y-m-d\TH:i:s+00:00') . '</lastmod>' . "\n";
+    echo '<lastmod>' . $current_datetime_utc . '</lastmod>' . "\n";
     echo '</sitemap>' . "\n";
 
     // イベントサイトマップ
     echo '<sitemap>' . "\n";
     echo '<loc>' . home_url('/sitemap-events.xml') . '</loc>' . "\n";
-    echo '<lastmod>' . date('Y-m-d\TH:i:s+00:00') . '</lastmod>' . "\n";
+    echo '<lastmod>' . $current_datetime_utc . '</lastmod>' . "\n";
     echo '</sitemap>' . "\n";
-    
+
     echo '</sitemapindex>' . "\n";
 }
 
@@ -893,10 +895,12 @@ function logic_nagoya_events_sitemap() {
     echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
     echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
 
+    $current_datetime_utc = current_datetime('UTC')->format(DATE_W3C);
+
     // イベント一覧ページ
     echo '<url>' . "\n";
     echo '<loc>' . get_post_type_archive_link('event') . '</loc>' . "\n";
-    echo '<lastmod>' . date('Y-m-d\TH:i:s+00:00') . '</lastmod>' . "\n";
+    echo '<lastmod>' . $current_datetime_utc . '</lastmod>' . "\n";
     echo '<changefreq>daily</changefreq>' . "\n";
     echo '<priority>0.8</priority>' . "\n";
     echo '</url>' . "\n";
@@ -911,7 +915,7 @@ function logic_nagoya_events_sitemap() {
     foreach ($events as $event) {
         echo '<url>' . "\n";
         echo '<loc>' . get_permalink($event->ID) . '</loc>' . "\n";
-        echo '<lastmod>' . get_the_modified_date('Y-m-d\TH:i:s+00:00', $event->ID) . '</lastmod>' . "\n";
+        echo '<lastmod>' . get_the_modified_date(DATE_W3C, $event->ID) . '</lastmod>' . "\n";
         echo '<changefreq>weekly</changefreq>' . "\n";
         echo '<priority>0.6</priority>' . "\n";
         echo '</url>' . "\n";
@@ -933,7 +937,7 @@ function logic_nagoya_posts_sitemap() {
     if ($posts_page_id) {
         echo '<url>' . "\n";
         echo '<loc>' . get_permalink($posts_page_id) . '</loc>' . "\n";
-        echo '<lastmod>' . get_the_modified_date('c', $posts_page_id) . '</lastmod>' . "\n";
+        echo '<lastmod>' . get_the_modified_date(DATE_W3C, $posts_page_id) . '</lastmod>' . "\n";
         echo '<changefreq>daily</changefreq>' . "\n";
         echo '<priority>0.8</priority>' . "\n";
         echo '</url>' . "\n";
@@ -951,7 +955,7 @@ function logic_nagoya_posts_sitemap() {
     foreach ($posts as $post) {
         echo '<url>' . "\n";
         echo '<loc>' . get_permalink($post->ID) . '</loc>' . "\n";
-        echo '<lastmod>' . get_post_modified_time('c', false, $post) . '</lastmod>' . "\n";
+        echo '<lastmod>' . get_post_modified_time(DATE_W3C, false, $post) . '</lastmod>' . "\n";
         echo '<changefreq>weekly</changefreq>' . "\n";
         echo '<priority>0.6</priority>' . "\n";
         echo '</url>' . "\n";
@@ -966,11 +970,13 @@ function logic_nagoya_posts_sitemap() {
 function logic_nagoya_pages_sitemap() {
     echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
     echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
-    
+
+    $current_datetime_utc = current_datetime('UTC')->format(DATE_W3C);
+
     // トップページ
     echo '<url>' . "\n";
     echo '<loc>' . home_url('/') . '</loc>' . "\n";
-    echo '<lastmod>' . date('Y-m-d\TH:i:s+00:00') . '</lastmod>' . "\n";
+    echo '<lastmod>' . $current_datetime_utc . '</lastmod>' . "\n";
     echo '<changefreq>daily</changefreq>' . "\n";
     echo '<priority>1.0</priority>' . "\n";
     echo '</url>' . "\n";
@@ -993,7 +999,7 @@ function logic_nagoya_pages_sitemap() {
         
         echo '<url>' . "\n";
         echo '<loc>' . get_permalink($page->ID) . '</loc>' . "\n";
-        echo '<lastmod>' . get_the_modified_date('Y-m-d\TH:i:s+00:00', $page->ID) . '</lastmod>' . "\n";
+        echo '<lastmod>' . get_the_modified_date(DATE_W3C, $page->ID) . '</lastmod>' . "\n";
         echo '<changefreq>' . $changefreq . '</changefreq>' . "\n";
         echo '<priority>' . $priority . '</priority>' . "\n";
         echo '</url>' . "\n";

--- a/page-events.php
+++ b/page-events.php
@@ -133,7 +133,7 @@ get_header();
         <div class="event-grid">
           <?php
           // Query upcoming events
-          $today = date('Y-m-d');
+          $today = wp_date('Y-m-d');
           $args = array(
             'post_type' => 'event',
             'posts_per_page' => 6,
@@ -161,7 +161,7 @@ get_header();
               $event_price = get_post_meta(get_the_ID(), 'event_ticket_price', true);
               
               // Format date
-              $formatted_date = $event_date ? date_i18n('Y.m.d', strtotime($event_date)) : '';
+              $formatted_date = $event_date ? wp_date('Y.m.d', strtotime($event_date)) : '';
               
               // Get event categories
               $categories = get_the_terms(get_the_ID(), 'event_category');


### PR DESCRIPTION
## Summary
- replace direct PHP date() usage with wp_date() for event metadata and schema output
- source sitemap timestamps from current_datetime() and standard DATE_W3C formatting
- update templates to display dates using WordPress-aware helpers

## Testing
- php -l functions.php
- php -l front-page.php
- php -l page-events.php
- php -l footer.php

------
https://chatgpt.com/codex/tasks/task_e_68d7f27ca4188333aff322ffb3b8f8b7