### PR TITLE
Add static meta tags in header and streamline SEO meta output

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -219,8 +219,6 @@ function logic_nagoya_setup() {
  */
 function logic_nagoya_seo_init() {
     // テーマサポートの追加
-    add_theme_support('title-tag');
-    
     // カスタムメタタグの追加
     add_action('wp_head', 'logic_nagoya_meta_tags', 1);
     add_action('wp_head', 'logic_nagoya_structured_data', 5);
@@ -252,17 +250,7 @@ function logic_nagoya_meta_tags() {
     if ($keywords) {
         echo '<meta name="keywords" content="' . esc_attr($keywords) . '">' . "\n";
     }
-    
-    // viewport（レスポンシブ対応）
-    echo '<meta name="viewport" content="width=device-width, initial-scale=1.0">' . "\n";
-    
-    // 文字エンコーディング
-    echo '<meta charset="' . get_bloginfo('charset') . '">' . "\n";
-    
-    // その他のメタタグ
-    echo '<meta name="format-detection" content="telephone=yes">' . "\n";
-    echo '<meta name="theme-color" content="#ca6666">' . "\n";
-    
+
     // 検索エンジン向け指示
     if (is_search() || is_404()) {
         echo '<meta name="robots" content="noindex, nofollow">' . "\n";

--- a/header.php
+++ b/header.php
@@ -13,6 +13,10 @@
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
+  <meta charset="<?php bloginfo( 'charset' ); ?>">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="format-detection" content="telephone=yes">
+  <meta name="theme-color" content="#ca6666">
   <?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>


### PR DESCRIPTION
## Summary
- add core meta tags directly within header.php before invoking wp_head
- restrict logic_nagoya_meta_tags to output only page-specific metadata
- remove redundant title-tag support declaration from SEO init hook

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80101121883338c2016790bfae000