### PR TITLE
Add security rel attributes to external links

### DIFF
--- a/Logic Nagoya SEO最適化完全実装ガイド.txt
+++ b/Logic Nagoya SEO最適化完全実装ガイド.txt
@@ -922,7 +922,7 @@ function logic_nagoya_seo_admin_page() {
     echo '<tr>';
     echo '<th>XMLサイトマップ</th>';
     echo '<td>';
-    echo '<p><a href="' . home_url('/sitemap.xml') . '" target="_blank">メインサイトマップを表示</a></p>';
+    echo '<p><a href="' . home_url('/sitemap.xml') . '" target="_blank" rel="noopener noreferrer">メインサイトマップを表示</a></p>';
     echo '<input type="submit" name="regenerate_sitemap" value="サイトマップ再生成" class="button-secondary">';
     echo '</td>';
     echo '</tr>';

--- a/Logic Nagoya 管理画面カスタマイズ完全ガイド.txt
+++ b/Logic Nagoya 管理画面カスタマイズ完全ガイド.txt
@@ -221,12 +221,12 @@ function logic_nagoya_recent_inquiries_widget() {
     // Google Analyticsへのリンク
     $analytics_id = get_field('google_analytics', 'option');
     if ($analytics_id) {
-        echo '<p><a href="https://analytics.google.com/" target="_blank" class="button">Google Analytics を開く</a></p>';
+        echo '<p><a href="https://analytics.google.com/" target="_blank" rel="noopener noreferrer" class="button">Google Analytics を開く</a></p>';
     }
     
     echo '<h4>よく使用するリンク</h4>';
     echo '<ul>';
-    echo '<li><a href="' . home_url('/') . '" target="_blank">サイトを表示</a></li>';
+    echo '<li><a href="' . home_url('/') . '" target="_blank" rel="noopener noreferrer">サイトを表示</a></li>';
     echo '<li><a href="' . admin_url('admin.php?page=logic-nagoya-performance') . '">パフォーマンス設定</a></li>';
     echo '<li><a href="' . admin_url('admin.php?page=logic-nagoya-seo') . '">SEO設定</a></li>';
     echo '</ul>';

--- a/footer.php
+++ b/footer.php
@@ -64,25 +64,25 @@
           <p class="footer-social-description"><?php esc_html_e( '最新情報はSNSでもチェックできます。フォローして最新のイベント情報をゲット！', 'logic-nagoya' ); ?></p>
           <div class="footer-social-links">
             <?php if ( get_theme_mod( 'logic_nagoya_twitter' ) ) : ?>
-            <a href="<?php echo esc_url( get_theme_mod( 'logic_nagoya_twitter' ) ); ?>" class="footer-social-link" target="_blank">
+            <a href="<?php echo esc_url( get_theme_mod( 'logic_nagoya_twitter' ) ); ?>" class="footer-social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-twitter"></i>
             </a>
             <?php endif; ?>
-            
+
             <?php if ( get_theme_mod( 'logic_nagoya_facebook' ) ) : ?>
-            <a href="<?php echo esc_url( get_theme_mod( 'logic_nagoya_facebook' ) ); ?>" class="footer-social-link" target="_blank">
+            <a href="<?php echo esc_url( get_theme_mod( 'logic_nagoya_facebook' ) ); ?>" class="footer-social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-facebook-f"></i>
             </a>
             <?php endif; ?>
-            
+
             <?php if ( get_theme_mod( 'logic_nagoya_instagram' ) ) : ?>
-            <a href="<?php echo esc_url( get_theme_mod( 'logic_nagoya_instagram' ) ); ?>" class="footer-social-link" target="_blank">
+            <a href="<?php echo esc_url( get_theme_mod( 'logic_nagoya_instagram' ) ); ?>" class="footer-social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-instagram"></i>
             </a>
             <?php endif; ?>
-            
+
             <?php if ( get_theme_mod( 'logic_nagoya_youtube' ) ) : ?>
-            <a href="<?php echo esc_url( get_theme_mod( 'logic_nagoya_youtube' ) ); ?>" class="footer-social-link" target="_blank">
+            <a href="<?php echo esc_url( get_theme_mod( 'logic_nagoya_youtube' ) ); ?>" class="footer-social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-youtube"></i>
             </a>
             <?php endif; ?>

--- a/front-page.php
+++ b/front-page.php
@@ -402,37 +402,37 @@ get_header();
           
           <div class="social-links">
             <?php if (get_theme_mod('logic_nagoya_twitter')) : ?>
-            <a href="<?php echo esc_url(get_theme_mod('logic_nagoya_twitter')); ?>" class="social-link" target="_blank">
+            <a href="<?php echo esc_url(get_theme_mod('logic_nagoya_twitter')); ?>" class="social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-twitter"></i>
             </a>
-            <?php endif; ?>
-            
-            <?php if (get_theme_mod('logic_nagoya_facebook')) : ?>
-            <a href="<?php echo esc_url(get_theme_mod('logic_nagoya_facebook')); ?>" class="social-link" target="_blank">
+          <?php endif; ?>
+
+          <?php if (get_theme_mod('logic_nagoya_facebook')) : ?>
+            <a href="<?php echo esc_url(get_theme_mod('logic_nagoya_facebook')); ?>" class="social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-facebook-f"></i>
             </a>
-            <?php endif; ?>
-            
-            <?php if (get_theme_mod('logic_nagoya_instagram')) : ?>
-            <a href="<?php echo esc_url(get_theme_mod('logic_nagoya_instagram')); ?>" class="social-link" target="_blank">
+          <?php endif; ?>
+
+          <?php if (get_theme_mod('logic_nagoya_instagram')) : ?>
+            <a href="<?php echo esc_url(get_theme_mod('logic_nagoya_instagram')); ?>" class="social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-instagram"></i>
             </a>
-            <?php endif; ?>
-            
-            <?php if (get_theme_mod('logic_nagoya_youtube')) : ?>
-            <a href="<?php echo esc_url(get_theme_mod('logic_nagoya_youtube')); ?>" class="social-link" target="_blank">
+          <?php endif; ?>
+
+          <?php if (get_theme_mod('logic_nagoya_youtube')) : ?>
+            <a href="<?php echo esc_url(get_theme_mod('logic_nagoya_youtube')); ?>" class="social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-youtube"></i>
             </a>
-            <?php endif; ?>
-            
-            <?php if (get_theme_mod('logic_nagoya_tiktok')) : ?>
-            <a href="<?php echo esc_url(get_theme_mod('logic_nagoya_tiktok')); ?>" class="social-link" target="_blank">
+          <?php endif; ?>
+
+          <?php if (get_theme_mod('logic_nagoya_tiktok')) : ?>
+            <a href="<?php echo esc_url(get_theme_mod('logic_nagoya_tiktok')); ?>" class="social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-tiktok"></i>
             </a>
-            <?php endif; ?>
-            
-            <?php if (get_theme_mod('logic_nagoya_line')) : ?>
-            <a href="<?php echo esc_url(get_theme_mod('logic_nagoya_line')); ?>" class="social-link" target="_blank">
+          <?php endif; ?>
+
+          <?php if (get_theme_mod('logic_nagoya_line')) : ?>
+            <a href="<?php echo esc_url(get_theme_mod('logic_nagoya_line')); ?>" class="social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-line"></i>
             </a>
             <?php endif; ?>

--- a/js/floor-map-page.js
+++ b/js/floor-map-page.js
@@ -23,7 +23,7 @@ jQuery(function ($) {
     const $toolbar = $('<div class="floormap-toolbar" role="group" aria-label="フロアマップ操作"></div>');
     const $zoomButton = $('<button type="button" class="floormap-toolbar-button" aria-pressed="false" aria-label="フロアマップを拡大"><i class="fas fa-search-plus"></i></button>');
     const $resetButton = $('<button type="button" class="floormap-toolbar-button" aria-label="拡大をリセット"><i class="fas fa-sync-alt"></i></button>');
-    const $downloadButton = $('<a class="floormap-toolbar-button" aria-label="フロアマップを新しいタブで開く" target="_blank" rel="noopener"><i class="fas fa-external-link-alt"></i></a>');
+    const $downloadButton = $('<a class="floormap-toolbar-button" aria-label="フロアマップを新しいタブで開く" target="_blank" rel="noopener noreferrer"><i class="fas fa-external-link-alt"></i></a>');
 
     $downloadButton.attr('href', $image.attr('src'));
 

--- a/logic-nagoya-about.html
+++ b/logic-nagoya-about.html
@@ -1686,10 +1686,10 @@
           <h3 class="footer-heading">FOLLOW US</h3>
           <p style="margin-bottom: 15px;">最新情報はSNSでもチェックできます。<br>フォローして最新のイベント情報をゲット！</p>
           <div class="footer-social-links">
-            <a href="https://twitter.com/logicnagoya" class="footer-social-link" target="_blank">
+            <a href="https://twitter.com/logicnagoya" class="footer-social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-twitter"></i>
             </a>
-            <a href="https://www.facebook.com/logicnagoya" class="footer-social-link" target="_blank">
+            <a href="https://www.facebook.com/logicnagoya" class="footer-social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-facebook-f"></i>
             </a>
           </div>

--- a/logic-nagoya-equipment.html
+++ b/logic-nagoya-equipment.html
@@ -1777,10 +1777,10 @@
           <h3 class="footer-heading">FOLLOW US</h3>
           <p style="margin-bottom: 15px;">最新情報はSNSでもチェックできます。<br>フォローして最新のイベント情報をゲット！</p>
           <div class="footer-social-links">
-            <a href="https://twitter.com/logicnagoya" class="footer-social-link" target="_blank">
+            <a href="https://twitter.com/logicnagoya" class="footer-social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-twitter"></i>
             </a>
-            <a href="https://www.facebook.com/logicnagoya" class="footer-social-link" target="_blank">
+            <a href="https://www.facebook.com/logicnagoya" class="footer-social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-facebook-f"></i>
             </a>
           </div>

--- a/logic-nagoya-events.html
+++ b/logic-nagoya-events.html
@@ -1963,10 +1963,10 @@
           <h3 class="footer-heading">FOLLOW US</h3>
           <p style="margin-bottom: 15px;">最新情報はSNSでもチェックできます。<br>フォローして最新のイベント情報をゲット！</p>
           <div class="footer-social-links">
-            <a href="https://twitter.com/logicnagoya" class="footer-social-link" target="_blank">
+            <a href="https://twitter.com/logicnagoya" class="footer-social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-twitter"></i>
             </a>
-            <a href="https://www.facebook.com/logicnagoya" class="footer-social-link" target="_blank">
+            <a href="https://www.facebook.com/logicnagoya" class="footer-social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-facebook-f"></i>
             </a>
           </div>

--- a/logic-nagoya-pricing.html
+++ b/logic-nagoya-pricing.html
@@ -1341,10 +1341,10 @@
           <h3 class="footer-heading">FOLLOW US</h3>
           <p style="margin-bottom: 15px;">最新情報はSNSでもチェックできます。<br>フォローして最新のイベント情報をゲット！</p>
           <div class="footer-social-links">
-            <a href="https://twitter.com/logicnagoya" class="footer-social-link" target="_blank">
+            <a href="https://twitter.com/logicnagoya" class="footer-social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-twitter"></i>
             </a>
-            <a href="https://www.facebook.com/logicnagoya" class="footer-social-link" target="_blank">
+            <a href="https://www.facebook.com/logicnagoya" class="footer-social-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-facebook-f"></i>
             </a>
           </div>

--- a/page-about.php
+++ b/page-about.php
@@ -238,22 +238,22 @@ get_header();
                   </p>
                   <div class="team-social">
                     <?php if (!empty($member['twitter'])) : ?>
-                      <a href="<?php echo esc_url($member['twitter']); ?>" class="team-social-link" target="_blank">
+                      <a href="<?php echo esc_url($member['twitter']); ?>" class="team-social-link" target="_blank" rel="noopener noreferrer">
                         <i class="fab fa-twitter"></i>
                       </a>
                     <?php endif; ?>
                     <?php if (!empty($member['facebook'])) : ?>
-                      <a href="<?php echo esc_url($member['facebook']); ?>" class="team-social-link" target="_blank">
+                      <a href="<?php echo esc_url($member['facebook']); ?>" class="team-social-link" target="_blank" rel="noopener noreferrer">
                         <i class="fab fa-facebook-f"></i>
                       </a>
                     <?php endif; ?>
                     <?php if (!empty($member['instagram'])) : ?>
-                      <a href="<?php echo esc_url($member['instagram']); ?>" class="team-social-link" target="_blank">
+                      <a href="<?php echo esc_url($member['instagram']); ?>" class="team-social-link" target="_blank" rel="noopener noreferrer">
                         <i class="fab fa-instagram"></i>
                       </a>
                     <?php endif; ?>
                     <?php if (!empty($member['linkedin'])) : ?>
-                      <a href="<?php echo esc_url($member['linkedin']); ?>" class="team-social-link" target="_blank">
+                      <a href="<?php echo esc_url($member['linkedin']); ?>" class="team-social-link" target="_blank" rel="noopener noreferrer">
                         <i class="fab fa-linkedin-in"></i>
                       </a>
                     <?php endif; ?>

--- a/page-floor-map.php
+++ b/page-floor-map.php
@@ -233,7 +233,7 @@ get_header();
               $google_maps_url = 'https://goo.gl/maps/YourGoogleMapsURL';
             }
             ?>
-            <a href="<?php echo esc_url($google_maps_url); ?>" class="btn btn-outline" target="_blank"><?php esc_html_e('Google Mapsで見る', 'logic-nagoya'); ?></a>
+            <a href="<?php echo esc_url($google_maps_url); ?>" class="btn btn-outline" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Google Mapsで見る', 'logic-nagoya'); ?></a>
           </div>
         </div>
       </div>

--- a/single-event.php
+++ b/single-event.php
@@ -140,7 +140,7 @@ while (have_posts()) :
                   <h4 class="ticket-name"><?php echo $name; ?></h4>
                   <p class="ticket-price"><?php echo esc_html($price); ?></p>
                   <?php if ($is_first && $event_ticket_url) : ?>
-                    <a href="<?php echo esc_url($event_ticket_url); ?>" class="btn btn-sm btn-outline" target="_blank"><?php esc_html_e('予約する', 'logic-nagoya'); ?></a>
+                    <a href="<?php echo esc_url($event_ticket_url); ?>" class="btn btn-sm btn-outline" target="_blank" rel="noopener noreferrer"><?php esc_html_e('予約する', 'logic-nagoya'); ?></a>
                   <?php endif; ?>
                 </div>
               <?php endforeach; ?>
@@ -148,7 +148,7 @@ while (have_posts()) :
               <h4 class="ticket-name"><?php esc_html_e('チケット', 'logic-nagoya'); ?></h4>
               <p class="ticket-price"><?php echo esc_html($event_ticket_price); ?></p>
               <?php if ($event_ticket_url) : ?>
-                <a href="<?php echo esc_url($event_ticket_url); ?>" class="btn btn-sm btn-outline" target="_blank"><?php esc_html_e('予約する', 'logic-nagoya'); ?></a>
+                <a href="<?php echo esc_url($event_ticket_url); ?>" class="btn btn-sm btn-outline" target="_blank" rel="noopener noreferrer"><?php esc_html_e('予約する', 'logic-nagoya'); ?></a>
               <?php endif; ?>
             <?php endif; ?>
             </div>
@@ -159,19 +159,19 @@ while (have_posts()) :
         <div class="modal-footer">
           <div class="share-links">
             <span style="margin-right: 10px;"><?php esc_html_e('このイベントをシェア：', 'logic-nagoya'); ?></span>
-            <a href="https://twitter.com/intent/tweet?url=<?php echo urlencode(get_permalink()); ?>&text=<?php echo urlencode(get_the_title()); ?>" class="share-link" target="_blank">
+            <a href="https://twitter.com/intent/tweet?url=<?php echo urlencode(get_permalink()); ?>&text=<?php echo urlencode(get_the_title()); ?>" class="share-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-twitter"></i>
             </a>
-            <a href="https://www.facebook.com/sharer/sharer.php?u=<?php echo urlencode(get_permalink()); ?>" class="share-link" target="_blank">
+            <a href="https://www.facebook.com/sharer/sharer.php?u=<?php echo urlencode(get_permalink()); ?>" class="share-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-facebook-f"></i>
             </a>
-            <a href="https://line.me/R/msg/text/?<?php echo urlencode(get_the_title() . ' ' . get_permalink()); ?>" class="share-link" target="_blank">
+            <a href="https://line.me/R/msg/text/?<?php echo urlencode(get_the_title() . ' ' . get_permalink()); ?>" class="share-link" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-line"></i>
             </a>
           </div>
           
           <?php if ($event_ticket_url) : ?>
-          <a href="<?php echo esc_url($event_ticket_url); ?>" class="btn btn-accent" target="_blank"><?php esc_html_e('チケットを予約する', 'logic-nagoya'); ?></a>
+          <a href="<?php echo esc_url($event_ticket_url); ?>" class="btn btn-accent" target="_blank" rel="noopener noreferrer"><?php esc_html_e('チケットを予約する', 'logic-nagoya'); ?></a>
           <?php endif; ?>
         </div>
         

--- a/テンプレート分割戦略・実装ガイド.txt
+++ b/テンプレート分割戦略・実装ガイド.txt
@@ -262,19 +262,19 @@ function logic_nagoya_fallback_menu() {
                     if ($social_media) :
                     ?>
                         <?php if ($social_media['twitter_url']) : ?>
-                        <a href="<?php echo esc_url($social_media['twitter_url']); ?>" class="footer-social-link" target="_blank">
+                        <a href="<?php echo esc_url($social_media['twitter_url']); ?>" class="footer-social-link" target="_blank" rel="noopener noreferrer">
                             <i class="fab fa-twitter"></i>
                         </a>
                         <?php endif; ?>
                         
                         <?php if ($social_media['facebook_url']) : ?>
-                        <a href="<?php echo esc_url($social_media['facebook_url']); ?>" class="footer-social-link" target="_blank">
+                        <a href="<?php echo esc_url($social_media['facebook_url']); ?>" class="footer-social-link" target="_blank" rel="noopener noreferrer">
                             <i class="fab fa-facebook-f"></i>
                         </a>
                         <?php endif; ?>
                         
                         <?php if ($social_media['instagram_url']) : ?>
-                        <a href="<?php echo esc_url($social_media['instagram_url']); ?>" class="footer-social-link" target="_blank">
+                        <a href="<?php echo esc_url($social_media['instagram_url']); ?>" class="footer-social-link" target="_blank" rel="noopener noreferrer">
                             <i class="fab fa-instagram"></i>
                         </a>
                         <?php endif; ?>


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to all external links that open in new tabs across theme templates
- update bundled static HTML and documentation snippets to reflect the same security best practice
- align the floor map toolbar button with the new rel attributes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d80224d7088333a7817da86432e7d8