### PR TITLE
Register sitemap query var and flush rewrite rules on theme activation

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -814,6 +814,16 @@ function logic_nagoya_sitemap_init() {
     // カスタムサイトマップの生成
     add_action('init', 'logic_nagoya_sitemap_rewrite_rules');
     add_action('template_redirect', 'logic_nagoya_sitemap_template');
+    add_filter('query_vars', 'logic_nagoya_register_sitemap_query_var');
+}
+
+/**
+ * サイトマップクエリ変数の登録
+ */
+function logic_nagoya_register_sitemap_query_var($vars) {
+    $vars[] = 'sitemap';
+
+    return $vars;
 }
 
 /**
@@ -1654,6 +1664,14 @@ function logic_nagoya_setup_default_menu() {
     }
 }
 add_action('after_switch_theme', 'logic_nagoya_setup_default_menu');
+
+/**
+ * テーマ有効化時にリライトルールを更新
+ */
+function logic_nagoya_flush_rewrite_rules_on_switch() {
+    flush_rewrite_rules();
+}
+add_action('after_switch_theme', 'logic_nagoya_flush_rewrite_rules_on_switch');
 
 /**
  * Create a default menu as a fallback


### PR DESCRIPTION
## Summary
- hook the sitemap query var registration into the sitemap initialization routine
- add the logic_nagoya_register_sitemap_query_var() helper to append the sitemap parameter
- flush rewrite rules on theme activation to refresh sitemap rewrites

## Testing
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68d790229e688333b6833687f862567c